### PR TITLE
allow building for scala 2.13

### DIFF
--- a/build.sc
+++ b/build.sc
@@ -25,7 +25,7 @@ trait ScalalibdiffTestModule extends TestModule with ScalaModule {
   def testFrameworks = Seq("utest.runner.Framework")
 }
 
-object jvm extends Cross[ScalalibdiffJvmModule]("2.11.12", "2.12.7", "2.13.12")
+object jvm extends Cross[ScalalibdiffJvmModule]("2.11.12", "2.12.7", "2.13.2")
 class ScalalibdiffJvmModule(val crossScalaVersion: String) extends ScalalibdiffModule {
   def platformSegment = "jvm"
   object test extends Tests with ScalalibdiffTestModule {
@@ -33,10 +33,10 @@ class ScalalibdiffJvmModule(val crossScalaVersion: String) extends ScalalibdiffM
   }
 }
 
-object js extends Cross[ScalalibdiffJsModule]("2.11.12", "2.12.7", "2.13.12")
+object js extends Cross[ScalalibdiffJsModule]("2.11.12", "2.12.7", "2.13.2")
 class ScalalibdiffJsModule(val crossScalaVersion: String) extends ScalalibdiffModule with ScalaJSModule {
   def platformSegment = "js"
-  def scalaJSVersion = "0.6.25"
+  def scalaJSVersion = "0.6.33"
   object test extends Tests with ScalalibdiffTestModule {
     def millSourcePath = build.millSourcePath / "test"
   }

--- a/build.sc
+++ b/build.sc
@@ -21,11 +21,11 @@ trait ScalalibdiffModule extends CrossScalaModule with ScalafmtModule with Publi
 }
 
 trait ScalalibdiffTestModule extends TestModule with ScalaModule {
-  def ivyDeps = Agg(ivy"com.lihaoyi::utest::0.6.6")
+  def ivyDeps = Agg(ivy"com.lihaoyi::utest::0.8.2")
   def testFrameworks = Seq("utest.runner.Framework")
 }
 
-object jvm extends Cross[ScalalibdiffJvmModule]("2.11.12", "2.12.7")
+object jvm extends Cross[ScalalibdiffJvmModule]("2.11.12", "2.12.7", "2.13.12")
 class ScalalibdiffJvmModule(val crossScalaVersion: String) extends ScalalibdiffModule {
   def platformSegment = "jvm"
   object test extends Tests with ScalalibdiffTestModule {
@@ -33,7 +33,7 @@ class ScalalibdiffJvmModule(val crossScalaVersion: String) extends ScalalibdiffM
   }
 }
 
-object js extends Cross[ScalalibdiffJsModule]("2.11.12", "2.12.7")
+object js extends Cross[ScalalibdiffJsModule]("2.11.12", "2.12.7", "2.13.12")
 class ScalalibdiffJsModule(val crossScalaVersion: String) extends ScalalibdiffModule with ScalaJSModule {
   def platformSegment = "js"
   def scalaJSVersion = "0.6.25"

--- a/build.sc
+++ b/build.sc
@@ -25,7 +25,7 @@ trait ScalalibdiffTestModule extends TestModule with ScalaModule {
   def testFrameworks = Seq("utest.runner.Framework")
 }
 
-object jvm extends Cross[ScalalibdiffJvmModule]("2.11.12", "2.12.7", "2.13.2")
+object jvm extends Cross[ScalalibdiffJvmModule]("2.11.12", "2.12.7", "2.13.12")
 class ScalalibdiffJvmModule(val crossScalaVersion: String) extends ScalalibdiffModule {
   def platformSegment = "jvm"
   object test extends Tests with ScalalibdiffTestModule {
@@ -33,10 +33,10 @@ class ScalalibdiffJvmModule(val crossScalaVersion: String) extends ScalalibdiffM
   }
 }
 
-object js extends Cross[ScalalibdiffJsModule]("2.11.12", "2.12.7", "2.13.2")
+object js extends Cross[ScalalibdiffJsModule]("2.11.12", "2.12.7", "2.13.12")
 class ScalalibdiffJsModule(val crossScalaVersion: String) extends ScalalibdiffModule with ScalaJSModule {
   def platformSegment = "js"
-  def scalaJSVersion = "0.6.33"
+  def scalaJSVersion = "1.14.0"
   object test extends Tests with ScalalibdiffTestModule {
     def millSourcePath = build.millSourcePath / "test"
   }

--- a/src/Diff.scala
+++ b/src/Diff.scala
@@ -69,8 +69,8 @@ object Diff {
   def text(original: String,
            modified: String,
            colored: Boolean = false): String = {
-    val originalLines = original.lines.toIndexedSeq
-    val modifiedLines = modified.lines.toIndexedSeq
+    val originalLines = original.linesIterator.toSeq
+    val modifiedLines = modified.linesIterator.toSeq
     val buff = new StringBuilder
     Diff(originalLines, modifiedLines).foreach {
       case Diff.Same(start, end, _, _) =>


### PR DESCRIPTION
Just some minor tweaks to get this to build in Scala 2.13.12, as I would really like to use this excellent library in a Scala 2.13 project.

The JVM tests still pass for all three Scala versions after these changes.